### PR TITLE
Fixes Issue 61

### DIFF
--- a/src/Timer.js
+++ b/src/Timer.js
@@ -11,7 +11,7 @@ const HOURS = 3600;
 const MINUTES = 60;
 const SECONDS = 1;
 const MAX_HOURS = 23 * 60 * 60;
-const MAX_MINUTES = 59;
+const MAX_MINUTES = 24 * 60;
 const MAX_SECONDS = 59;
 const MIN_TIME = 0;
 
@@ -31,7 +31,7 @@ class Timer extends React.Component {
   };
 
   decreaseHours = () => {
-    if (this.state.timeRemaining <= MIN_TIME) {
+    if (this.state.timeRemaining <= HOURS) {
       return;
     }
 
@@ -47,7 +47,7 @@ class Timer extends React.Component {
   };
 
   decreaseMinutes = () => {
-    if (this.state.timeRemaining <= MIN_TIME) {
+    if (this.state.timeRemaining <= MINUTES) {
       return;
     }
 

--- a/src/Timer.js
+++ b/src/Timer.js
@@ -10,8 +10,8 @@ import Alert from './Alert';
 const HOURS = 3600;
 const MINUTES = 60;
 const SECONDS = 1;
-const MAX_HOURS = 23 * 60 * 60;
-const MAX_MINUTES = 24 * 60;
+const MAX_HOURS = (23 * 60 * 60) - 1;
+const MAX_MINUTES = (24 * 60) - 1;
 const MAX_SECONDS = 59;
 const MIN_TIME = 0;
 

--- a/src/Timer.test.js
+++ b/src/Timer.test.js
@@ -77,7 +77,7 @@ describe('Timer', () => {
         button.simulate('click');
 
         // Assert
-        expect(wrapper.state().timeRemaining).toEqual(0);
+        expect(wrapper.state().timeRemaining).toEqual(3600);
         expect(wrapper.state().timeRemaining).not.toBe(-1 * hours);
       });
     });
@@ -106,8 +106,8 @@ describe('Timer', () => {
         button.simulate('click');
 
         // Assert
-        expect(wrapper.state().timeRemaining).toEqual(59 * minutes);
-        expect(wrapper.state().timeRemaining).not.toBe(60 * minutes);
+        expect(wrapper.state().timeRemaining).toEqual(60 * minutes);
+        expect(wrapper.state().timeRemaining).not.toBe(61 * minutes);
       });
     });
 
@@ -135,7 +135,7 @@ describe('Timer', () => {
         button.simulate('click');
 
         // Assert
-        expect(wrapper.state().timeRemaining).toEqual(0);
+        expect(wrapper.state().timeRemaining).toEqual(60);
         expect(wrapper.state().timeRemaining).not.toBe(-1 * minutes);
       });
     });


### PR DESCRIPTION
Issue 61 reflects a bug in which one is able to decrement the timer value into the negatives if you first increment seconds. This is a fix which has minutes and hours checking for minimum minutes and hours rather than a zero value. It also contains test updates to reflect these changes in expected values.