### PR TITLE
Update tests to remove warnings

### DIFF
--- a/src/components/Timer/AdjustTimerButtonGroup.js
+++ b/src/components/Timer/AdjustTimerButtonGroup.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button } from 'react-materialize';
-import { func, number, bool } from 'prop-types';
+import { func } from 'prop-types';
 
 const AdjustTimerButtonGroup = props => {
   return (
@@ -65,18 +65,12 @@ const AdjustTimerButtonGroup = props => {
 };
 
 AdjustTimerButtonGroup.propTypes = {
-  onStart: func.isRequired,
-  onPause: func.isRequired,
-  onClear: func.isRequired,
-  handleDismiss: func.isRequired,
   increaseHours: func.isRequired,
   decreaseHours: func.isRequired,
   increaseMinutes: func.isRequired,
   decreaseMinutes: func.isRequired,
   increaseSeconds: func.isRequired,
-  decreaseSeconds: func.isRequired,
-  timeRemaining: number,
-  startClicked: bool
+  decreaseSeconds: func.isRequired
 };
 
 export default AdjustTimerButtonGroup;

--- a/src/components/Timer/__tests__/Timer.test.js
+++ b/src/components/Timer/__tests__/Timer.test.js
@@ -14,6 +14,13 @@ describe('Timer', () => {
   const onStartMock = jest.fn();
   const onPauseMock = jest.fn();
   const onClearMock = jest.fn();
+  const handleDismissMock = jest.fn();
+  const increaseHoursMock = jest.fn();
+  const decreaseHoursMock = jest.fn();
+  const increaseMinutesMock = jest.fn();
+  const decreaseMinutesMock = jest.fn();
+  const increaseSecondsMock = jest.fn();
+  const decreaseSecondsMock = jest.fn();
 
   beforeEach(() => {
     wrapper = shallow(
@@ -23,6 +30,13 @@ describe('Timer', () => {
         onStart={onStartMock}
         onPause={onPauseMock}
         onClear={onClearMock}
+        handleDismiss={handleDismissMock}
+        increaseHours={increaseHoursMock}
+        decreaseHours={decreaseHoursMock}
+        increaseMinutes={increaseMinutesMock}
+        decreaseMinutes={decreaseMinutesMock}
+        increaseSeconds={increaseSecondsMock}
+        decreaseSeconds={decreaseSecondsMock}
       />
     );
   });
@@ -34,22 +48,74 @@ describe('Timer', () => {
   it('shows alert when start is clicked and time is zero', () => {
     expect(wrapper.find('Alert').props().show).toBe(true);
   });  it('does not show alert when start is not clicked and time is zero', () => {
-    wrapper = shallow(<Timer startClicked={false} timeRemaining={0} />);
+    wrapper = shallow(<Timer
+                        startClicked={false}
+                        timeRemaining={0}
+                        onStart={onStartMock}
+                        onPause={onPauseMock}
+                        onClear={onClearMock}
+                        handleDismiss={handleDismissMock}
+                        increaseHours={increaseHoursMock}
+                        decreaseHours={decreaseHoursMock}
+                        increaseMinutes={increaseMinutesMock}
+                        decreaseMinutes={decreaseMinutesMock}
+                        increaseSeconds={increaseSecondsMock}
+                        decreaseSeconds={decreaseSecondsMock}
+                        />);
     expect(wrapper.find('Alert').props().show).toBe(false);
   });
 
   it('does not show alert when start is clicked and time is not zero', () => {
-    wrapper = shallow(<Timer startClicked timeRemaining={10} />);
+    wrapper = shallow(<Timer
+                        startClicked={false}
+                        timeRemaining={10}
+                        onStart={onStartMock}
+                        onPause={onPauseMock}
+                        onClear={onClearMock}
+                        handleDismiss={handleDismissMock}
+                        increaseHours={increaseHoursMock}
+                        decreaseHours={decreaseHoursMock}
+                        increaseMinutes={increaseMinutesMock}
+                        decreaseMinutes={decreaseMinutesMock}
+                        increaseSeconds={increaseSecondsMock}
+                        decreaseSeconds={decreaseSecondsMock}
+                        />);
     expect(wrapper.find('Alert').props().show).toBe(false);
   });
 
   it('does not show alert when start is not clicked and time is zero', () => {
-    wrapper = shallow(<Timer startClicked={false} timeRemaining={0} />);
+    wrapper = shallow(<Timer
+                        startClicked={false}
+                        timeRemaining={0}
+                        onStart={onStartMock}
+                        onPause={onPauseMock}
+                        onClear={onClearMock}
+                        handleDismiss={handleDismissMock}
+                        increaseHours={increaseHoursMock}
+                        decreaseHours={decreaseHoursMock}
+                        increaseMinutes={increaseMinutesMock}
+                        decreaseMinutes={decreaseMinutesMock}
+                        increaseSeconds={increaseSecondsMock}
+                        decreaseSeconds={decreaseSecondsMock}
+                        />);
     expect(wrapper.find('Alert').props().show).toBe(false);
   });
 
   it('does not show alert when start is clicked and time is not zero', () => {
-    wrapper = shallow(<Timer startClicked timeRemaining={10} />);
+    wrapper = shallow(<Timer
+                        startClicked={false}
+                        timeRemaining={10}
+                        onStart={onStartMock}
+                        onPause={onPauseMock}
+                        onClear={onClearMock}
+                        handleDismiss={handleDismissMock}
+                        increaseHours={increaseHoursMock}
+                        decreaseHours={decreaseHoursMock}
+                        increaseMinutes={increaseMinutesMock}
+                        decreaseMinutes={decreaseMinutesMock}
+                        increaseSeconds={increaseSecondsMock}
+                        decreaseSeconds={decreaseSecondsMock}
+                        />);
     expect(wrapper.find('Alert').props().show).toBe(false);
   });
 

--- a/src/components/Timer/__tests__/Timer.test.js
+++ b/src/components/Timer/__tests__/Timer.test.js
@@ -22,22 +22,24 @@ describe('Timer', () => {
   const increaseSecondsMock = jest.fn();
   const decreaseSecondsMock = jest.fn();
 
+  const props = {
+          startClicked: true,
+          timeRemaining: 0,
+          onStart: onStartMock,
+          onPause: onPauseMock,
+          onClear: onClearMock,
+          handleDismiss: handleDismissMock,
+          increaseHours: increaseHoursMock,
+          decreaseHours: decreaseHoursMock,
+          increaseMinutes: increaseMinutesMock,
+          decreaseMinutes: decreaseMinutesMock,
+          increaseSeconds: increaseSecondsMock,
+          decreaseSeconds: decreaseSecondsMock
+        };
+
   beforeEach(() => {
     wrapper = shallow(
-      <Timer
-        startClicked
-        timeRemaining={0}
-        onStart={onStartMock}
-        onPause={onPauseMock}
-        onClear={onClearMock}
-        handleDismiss={handleDismissMock}
-        increaseHours={increaseHoursMock}
-        decreaseHours={decreaseHoursMock}
-        increaseMinutes={increaseMinutesMock}
-        decreaseMinutes={decreaseMinutesMock}
-        increaseSeconds={increaseSecondsMock}
-        decreaseSeconds={decreaseSecondsMock}
-      />
+      <Timer {...props} />
     );
   });
 
@@ -48,74 +50,22 @@ describe('Timer', () => {
   it('shows alert when start is clicked and time is zero', () => {
     expect(wrapper.find('Alert').props().show).toBe(true);
   });  it('does not show alert when start is not clicked and time is zero', () => {
-    wrapper = shallow(<Timer
-                        startClicked={false}
-                        timeRemaining={0}
-                        onStart={onStartMock}
-                        onPause={onPauseMock}
-                        onClear={onClearMock}
-                        handleDismiss={handleDismissMock}
-                        increaseHours={increaseHoursMock}
-                        decreaseHours={decreaseHoursMock}
-                        increaseMinutes={increaseMinutesMock}
-                        decreaseMinutes={decreaseMinutesMock}
-                        increaseSeconds={increaseSecondsMock}
-                        decreaseSeconds={decreaseSecondsMock}
-                        />);
+    wrapper = shallow(<Timer {...props} startClicked={false} />);
     expect(wrapper.find('Alert').props().show).toBe(false);
   });
 
   it('does not show alert when start is clicked and time is not zero', () => {
-    wrapper = shallow(<Timer
-                        startClicked={false}
-                        timeRemaining={10}
-                        onStart={onStartMock}
-                        onPause={onPauseMock}
-                        onClear={onClearMock}
-                        handleDismiss={handleDismissMock}
-                        increaseHours={increaseHoursMock}
-                        decreaseHours={decreaseHoursMock}
-                        increaseMinutes={increaseMinutesMock}
-                        decreaseMinutes={decreaseMinutesMock}
-                        increaseSeconds={increaseSecondsMock}
-                        decreaseSeconds={decreaseSecondsMock}
-                        />);
+    wrapper = shallow(<Timer {...props} startClicked={false} timeRemaining={10} />);
     expect(wrapper.find('Alert').props().show).toBe(false);
   });
 
   it('does not show alert when start is not clicked and time is zero', () => {
-    wrapper = shallow(<Timer
-                        startClicked={false}
-                        timeRemaining={0}
-                        onStart={onStartMock}
-                        onPause={onPauseMock}
-                        onClear={onClearMock}
-                        handleDismiss={handleDismissMock}
-                        increaseHours={increaseHoursMock}
-                        decreaseHours={decreaseHoursMock}
-                        increaseMinutes={increaseMinutesMock}
-                        decreaseMinutes={decreaseMinutesMock}
-                        increaseSeconds={increaseSecondsMock}
-                        decreaseSeconds={decreaseSecondsMock}
-                        />);
+    wrapper = shallow(<Timer {...props} startClicked={false} />);
     expect(wrapper.find('Alert').props().show).toBe(false);
   });
 
   it('does not show alert when start is clicked and time is not zero', () => {
-    wrapper = shallow(<Timer
-                        startClicked={false}
-                        timeRemaining={10}
-                        onStart={onStartMock}
-                        onPause={onPauseMock}
-                        onClear={onClearMock}
-                        handleDismiss={handleDismissMock}
-                        increaseHours={increaseHoursMock}
-                        decreaseHours={decreaseHoursMock}
-                        increaseMinutes={increaseMinutesMock}
-                        decreaseMinutes={decreaseMinutesMock}
-                        increaseSeconds={increaseSecondsMock}
-                        decreaseSeconds={decreaseSecondsMock}
-                        />);
+    wrapper = shallow(<Timer {...props} startClicked={false} timeRemaining={10} />);
     expect(wrapper.find('Alert').props().show).toBe(false);
   });
 

--- a/src/components/Timer/__tests__/__snapshots__/Timer.test.js.snap
+++ b/src/components/Timer/__tests__/__snapshots__/Timer.test.js.snap
@@ -4,6 +4,7 @@ exports[`Timer renders correctly 1`] = `
 <Row>
   <Alert
     msg="Time is up!"
+    onDismiss={[Function]}
     show={true}
   />
   <Col
@@ -41,7 +42,14 @@ exports[`Timer renders correctly 1`] = `
           </tr>
         </thead>
         <tbody>
-          <AdjustTimerButtonGroup />
+          <AdjustTimerButtonGroup
+            decreaseHours={[Function]}
+            decreaseMinutes={[Function]}
+            decreaseSeconds={[Function]}
+            increaseHours={[Function]}
+            increaseMinutes={[Function]}
+            increaseSeconds={[Function]}
+          />
           <tr>
             <td>
               <h1


### PR DESCRIPTION
Update tests to remove warnings generated from lack of prop values in timer test