### PR TITLE
Close #70. Add localStorage for state retention in Timer and Stopwatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "private": true,
   "dependencies": {
+    "jest-localstorage-mock": "^2.2.0",
     "prop-types": "^15.6.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test:lint:js": "eslint --fix --ignore-path .gitignore --ext=js --ext=jsx .",
-    "test:unit": "react-scripts test  --coverage --env=jsdom",
+    "test:unit": "react-scripts test --coverage --env=jsdom",
     "test": "run-s test:**",
     "eject": "react-scripts eject"
   },

--- a/src/components/Stopwatch/StopwatchContainer.js
+++ b/src/components/Stopwatch/StopwatchContainer.js
@@ -9,6 +9,22 @@ export default class StopwatchContainer extends React.Component {
 
   timer = null;
 
+  componentDidMount = () => {
+    // Uses localStorage / 0 to set state
+    const localStorageRef = localStorage.getItem('counter');
+    this.setState({ counter: parseInt(localStorageRef, 0) || 0 });
+  };
+
+  componentDidUpdate() {
+    // Sets the locastorage
+    localStorage.setItem('counter', this.state.counter);
+  }
+
+  componentWillUnmount() {
+    // Sets counter to 0 if component is unmounted
+    localStorage.setItem('counter', 0);
+  }
+
   handleStart = () => {
     if (this.state.clicked === false) {
       clearInterval(this.timer);

--- a/src/components/Stopwatch/__tests__/StopwatchContainer.test.js
+++ b/src/components/Stopwatch/__tests__/StopwatchContainer.test.js
@@ -3,6 +3,7 @@ import Enzyme from 'enzyme';
 import { shallow } from 'enzyme';
 import StopwatchContainer from '../StopwatchContainer';
 import Adapter from 'enzyme-adapter-react-16';
+import 'jest-localstorage-mock';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -41,7 +42,7 @@ describe('StopwatchContainer', () => {
     expect(spy).toHaveBeenCalled();
   });
 
-  it('pauses the tick function from chaning the timeRemaining state ', () => {
+  it('pauses the tick function from chaning the counter state ', () => {
     // Arrange
     const spy = jest.spyOn(wrapper.instance(), 'handlePause');
     wrapper.instance().handleStart();
@@ -94,6 +95,57 @@ describe('StopwatchContainer', () => {
       expect(wrapper.state().counter).toEqual(1);
       expect(wrapper.state().counter).not.toBe(-1);
       expect(wrapper.state().counter).not.toBe(0);
+    });
+  });
+
+  describe('#componentDidMount', () => {
+    it('sets an initial counter value from localstorage when available', () => {
+      // Arrange
+      const initialCounter = Math.round(Math.random() * 10000);
+      localStorage.setItem('counter', initialCounter);
+
+      // Act
+      const subject = shallow(<StopwatchContainer />);
+
+      // Assert
+      expect(subject.state().counter).toEqual(initialCounter);
+    });
+    it('sets a sane default counter value', () => {
+      // Arrange
+      localStorage.setItem('counter', null);
+
+      // Act
+      const subject = shallow(<StopwatchContainer />);
+
+      // Assert
+      expect(subject.state().counter).toEqual(0);
+    });
+  });
+
+  describe('#componentDidUpdate', () => {
+    it('sets state to localStorage value ', () => {
+      // Arrange
+      localStorage.setItem('counter', 999);
+      wrapper.setState({ counter: 1214 });
+
+      // Act
+      wrapper.update();
+
+      // Assert
+      expect(localStorage.getItem('counter')).toEqual('1214');
+    });
+  });
+
+  describe('#componentWillUnmount', () => {
+    it('resets the stored state in localstorage', () => {
+      // Arrange
+      localStorage.setItem('counter', 999);
+
+      // Act
+      wrapper.instance().componentWillUnmount();
+
+      // Assert
+      expect(localStorage.getItem('counter')).toEqual('0');
     });
   });
 });

--- a/src/components/Timer/TimerContainer.js
+++ b/src/components/Timer/TimerContainer.js
@@ -15,6 +15,22 @@ class TimerContainer extends React.Component {
 
   timer = null;
 
+  componentDidMount = () => {
+    // Uses localStorage / 0 to set state
+    const localStorageRef = localStorage.getItem('timeRemaining');
+    this.setState({ timeRemaining: parseInt(localStorageRef, 0) || 0 });
+  };
+
+  componentDidUpdate() {
+    // Sets the locastorage
+    localStorage.setItem('timeRemaining', this.state.timeRemaining);
+  }
+
+  componentWillUnmount() {
+    // Sets counter to 0 if component is unmounted
+    localStorage.setItem('timeRemaining', 0);
+  }
+
   increaseHours = () => {
     if (this.state.timeRemaining >= MAX_TIME) {
       return;

--- a/src/components/Timer/__tests__/TimerContainer.test.js
+++ b/src/components/Timer/__tests__/TimerContainer.test.js
@@ -4,6 +4,7 @@ import TimerContainer from '../TimerContainer';
 import { shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import toJson from 'enzyme-to-json';
+import 'jest-localstorage-mock';
 
 Enzyme.configure({ adapter: new Adapter() });
 jest.useFakeTimers();
@@ -37,10 +38,7 @@ describe('Timer', () => {
         handleClear={handleClearMock}
       />
     );
-  });
-
-  afterEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   it('renders correctly', () => {
@@ -115,6 +113,7 @@ describe('Timer', () => {
     describe('clicking the + minutes button', () => {
       it('increases the minutes in the time remaining', () => {
         // Arrange
+        wrapper.setState({ timeRemaining: 0 });
         const spy = jest.spyOn(wrapper.instance(), 'increaseMinutes');
 
         // Act
@@ -395,6 +394,57 @@ describe('Timer', () => {
 
       // Assert
       expect(wrapper.state().startClicked).toBe(false);
+    });
+  });
+
+  describe('#componentDidMount', () => {
+    it('sets an initial timeRemaining value from localstorage when available', () => {
+      // Arrange
+      const initialTime = Math.round(Math.random() * 10000);
+      localStorage.setItem('timeRemaining', initialTime);
+
+      // Act
+      const subject = shallow(<TimerContainer />);
+
+      // Assert
+      expect(subject.state().timeRemaining).toEqual(initialTime);
+    });
+    it('sets a sane default timeRemaining value', () => {
+      // Arrange
+      localStorage.setItem('timeRemaining', null);
+
+      // Act
+      const subject = shallow(<TimerContainer />);
+
+      // Assert
+      expect(subject.state().timeRemaining).toEqual(0);
+    });
+  });
+
+  describe('#componentDidUpdate', () => {
+    it('sets state to localStorage value ', () => {
+      // Arrange
+      localStorage.setItem('timeRemaining', 999);
+      wrapper.setState({ timeRemaining: 1214 });
+
+      // Act
+      wrapper.update();
+
+      // Assert
+      expect(localStorage.getItem('timeRemaining')).toEqual('1214');
+    });
+  });
+
+  describe('#componentWillUnmount', () => {
+    it('resets the stored state in localstorage', () => {
+      // Arrange
+      localStorage.setItem('timeRemaining', 999);
+
+      // Act
+      wrapper.instance().componentWillUnmount();
+
+      // Assert
+      expect(localStorage.getItem('timeRemaining')).toEqual('0');
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4149,6 +4149,10 @@ jest-jasmine2@^20.0.4:
     once "^1.4.0"
     p-map "^1.1.1"
 
+jest-localstorage-mock@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jest-localstorage-mock/-/jest-localstorage-mock-2.2.0.tgz#ce9a9de01dfdde2ad8aa08adf73acc7e5cc394cf"
+
 jest-matcher-utils@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz#b3a6b8e37ca577803b0832a98b164f44b7815612"


### PR DESCRIPTION
- Add logic for state to be set with localStorage when there is a refresh/update.
- Add logic for localStorage to be set to 0 when unmounted.
- Add jest-localstorage-mock package for testing
- Remove afterEach function in TimerCotainer.test.js file because it was affecting the localStorage mock.
- Add jest.resetAllMocks() to 3 individual tests that need the afterEach function to run mocks reset.